### PR TITLE
Add document counting & limits section to AI Desk Pro

### DIFF
--- a/src/solutions/aidesk-pro/fundamentals/documents.md
+++ b/src/solutions/aidesk-pro/fundamentals/documents.md
@@ -45,6 +45,11 @@ To learn more about each document type and how to manage them:
 - **[Managing SharePoint Libraries](./sharepoint-libraries.md)** - Discover how to connect SharePoint sites and synchronize document libraries
 - **[Managing SharePoint Pages](./sharepoint-pages.md)** - Explore how to index SharePoint pages as knowledge sources
 
+# Document Counting & Limits
+
+- **1 document = 20 pages.** Regardless of actual page count, each document consumes 20 pages from your quota.
+- **The contracted document count is a total, not cumulative.** The limit applies across all your document sources combined — it is not renewed or added per source or per period.
+
 # General Best Practices
 
 - Regularly review and update your document sources


### PR DESCRIPTION
## Summary
- Adds a new **Document Counting & Limits** section to the AI Desk Pro documents overview page
- Clarifies that 1 document = 20 pages (regardless of actual page count)
- Clarifies that the contracted document count is a global total, not cumulative per source or period

🤖 Generated with [Claude Code](https://claude.com/claude-code)