### PR TITLE
docs(aidesk): per-agent answer model selection

### DIFF
--- a/src/solutions/aidesk-pro/changelog.md
+++ b/src/solutions/aidesk-pro/changelog.md
@@ -33,6 +33,7 @@ This change log documents the updates, bug fixes, and feature enhancements for A
 
 **User Stories:**
 1. **Reviewing User History:** Enhanced the administrator's ability to review user history for quality assessment.
+2. **Per-Agent Answer Model Selection (Preview):** Administrators can now choose the AI model that generates an agent's responses — Default (GPT-4o-mini), Claude Opus 4.8 (Preview), or Mistral Large 3 (Preview) — from Agent Customization, with a per-model credit weight, a change-confirmation dialog requiring consent for Preview models, and a record of the last model change.
 
 #### Additional Information
 - This document is subject to updates as new changes and improvements are made to AI desk PRO.

--- a/src/solutions/aidesk-pro/fundamentals/Agent-customization.md
+++ b/src/solutions/aidesk-pro/fundamentals/Agent-customization.md
@@ -75,6 +75,45 @@ These settings influence:
 
 Each feature can be enabled or disabled depending on organizational needs.
 
+# Model
+
+The Model section lets administrators choose which AI model generates the agent's responses. It is located in the **Features** tab of Agent Customization.
+
+## Answer model
+
+The **Answer model** setting defines the AI model used to generate the agent's replies. The available options are:
+
+- **Default** — the standard model (today GPT-4o-mini). Recommended for most agents.
+- **Claude Opus 4.8 (Preview)** — Anthropic's Claude Opus, served through the Anthropic API.
+- **Mistral Large 3 (Preview)** — Mistral's Large 3 model, served through Azure AI Foundry.
+
+::: tip
+The selected model is used for the agent's **responses only**. Semantic processing — embeddings, knowledge search, and reranking — always runs on the default model, so changing the answer model does not affect how the agent retrieves knowledge.
+:::
+
+### Credit consumption
+
+Each model has a **credit weight**, shown as a tooltip next to the selector (for example, `2×`). Exchanges with the agent count toward your session credit consumption at that weight, so a model with a higher weight consumes credits faster. The Default model has the lowest weight.
+
+### Changing the model
+
+Selecting a different model opens a confirmation dialog before the change is applied:
+
+1. In **Configuration > Agent Customization > Features**, open the **Answer model** selector.
+2. Choose the desired model.
+3. Review the confirmation dialog, which states:
+   - the change applies **immediately**, including to conversations currently in progress;
+   - past exchanges are **not** recalculated;
+   - the credit weight of the selected model.
+4. For a Preview model (Claude, Mistral), review the linked **Terms of Service** and tick the mandatory consent checkbox acknowledging that this agent's conversation data will be processed by the model's provider.
+5. Confirm to apply the change.
+
+The most recent change is shown below the selector as a *"Last changed from … to … by … on …"* line, providing a simple audit trail of who switched the model and when.
+
+::: warning
+Claude Opus 4.8 and Mistral Large 3 are Preview features. Review the [Preview Terms](/solutions/aidesk-pro/preview-features.html) before selecting them, and confirm the **Multi-Model** feature is available on your subscription (it appears in the subscription **Preview features** card).
+:::
+
 # Privacy & Security
 
 ## Anonymous mode

--- a/src/solutions/aidesk-pro/whats-new.md
+++ b/src/solutions/aidesk-pro/whats-new.md
@@ -5,6 +5,9 @@ This "What's New" page for AI desk PRO provides insights into the latest updates
 
 #### What's New in AI desk PRO
 
+**AI Model Choice**
+- **Per-Agent Answer Model (Preview):** Administrators can now choose the AI model used to generate an agent's responses — Default (GPT-4o-mini), Claude Opus 4.8 (Preview), or Mistral Large 3 (Preview) — directly from Agent Customization. The choice applies to the agent's replies only; knowledge retrieval continues to use the default model. Each model carries a credit weight shown next to the selector, and switching to a Preview model requires accepting its provider's terms of service.
+
 **Administrator Tools Enhancements**
 - **Review User History:** Administrators now have enhanced capabilities to review users' history. This feature is essential for assessing the quality of answers and interactions within Microsoft Teams, ensuring high standards are maintained.
 


### PR DESCRIPTION
## What changed for the user

Documents the **per-agent answer model selection** feature (AI-Desk-Pro PR [#183](https://github.com/Witivio/AI-Desk-Pro/pull/183), closes #174).

Administrators can now pick, in **Configuration > Agent Customization > Features**, the AI model used to generate an agent's responses:
- **Default** (GPT-4o-mini)
- **Claude Opus 4.8 (Preview)**
- **Mistral Large 3 (Preview)**

The model applies to the agent's replies only — semantic processing (embeddings, search, reranking) stays on the default model. Each model has a credit weight shown next to the selector; switching to a Preview model opens a confirmation dialog with a Terms of Service link and a mandatory consent checkbox. The last change is shown as an audit line.

## Pages touched
- `src/solutions/aidesk-pro/fundamentals/Agent-customization.md` — new **Model** section (Answer model, credit weight, change flow, Preview warning).
- `src/solutions/aidesk-pro/changelog.md` — new User Story entry.
- `src/solutions/aidesk-pro/whats-new.md` — new *AI Model Choice* highlight.

No new page → `config.js` unchanged (feature documented in its Fundamentals page, matching the Web Search / SourceSense / MCP Preview pattern).

## Screenshot TODOs
- [ ] Screenshot of the **Answer model** selector with the Preview badge + credit-weight tooltip.
- [ ] Screenshot of the model-change confirmation dialog (consent checkbox + Terms of Service link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)